### PR TITLE
ci(ios): release dist.zip (+ Package.swift) instead of dist.tar.gz

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -87,4 +87,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ${{ matrix.config.target }}.zip
+          files: |
+            ${{ matrix.config.target }}.zip
+            build/${{ matrix.config.target }}/dist/Package.swift

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Github Action - Upload
         uses: actions/upload-artifact@v4
         with:
-          name: artifact-${{ matrix.config.target }}.tar.gz
-          path: build/${{ matrix.config.target }}/dist/dist.tar.gz
+          name: artifact-${{ matrix.config.target }}.zip
+          path: build/${{ matrix.config.target }}/dist/dist.zip
 
       - name: Nativium - Dist Upload
         if: startsWith(github.ref, 'refs/tags/')
@@ -80,11 +80,11 @@ jobs:
 
       - name: Release - Setup
         if: startsWith(github.ref, 'refs/tags/')
-        run: mv build/${{ matrix.config.target }}/dist/dist.tar.gz ${{ matrix.config.target }}.tar.gz
+        run: mv build/${{ matrix.config.target }}/dist/dist.zip ${{ matrix.config.target }}.zip
 
       - name: Release
         id: upload-release-asset
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ${{ matrix.config.target }}.tar.gz
+          files: ${{ matrix.config.target }}.zip


### PR DESCRIPTION
## Problem

The iOS release job failed with:

```
mv: rename build/ios/dist/dist.tar.gz to ios.tar.gz: No such file or directory
```

The iOS dist now produces `build/ios/dist/dist.zip` (SPM) instead of `dist.tar.gz`, so `ios.yml` referenced a file that no longer exists.

## Fix

- `ios.yml`: artifact upload, the release `mv`, and the release asset now reference `dist.zip` / `ios.zip`.
- Also attach `Package.swift` to the GitHub release, next to the xcframework zip, so consumers can grab the SPM manifest from the release too (in addition to S3).

Only `ios.yml` changed; the other targets still produce `tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)